### PR TITLE
Fix user duplication bug

### DIFF
--- a/CrDuels/src/main/java/com/crduels/controller/UsuarioController.java
+++ b/CrDuels/src/main/java/com/crduels/controller/UsuarioController.java
@@ -19,9 +19,13 @@ public class UsuarioController {
     }
 
     @PostMapping("/registro")
-    public ResponseEntity<Usuario> registrar(@Valid @RequestBody Usuario usuario) {
-        Usuario nuevo = usuarioService.registrarUsuario(usuario);
-        return ResponseEntity.ok(nuevo);
+    public ResponseEntity<?> registrar(@Valid @RequestBody Usuario usuario) {
+        try {
+            Usuario nuevo = usuarioService.registrarUsuario(usuario);
+            return ResponseEntity.status(201).body(nuevo);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
     }
 
     @GetMapping("/{id}")

--- a/CrDuels/src/main/java/com/crduels/service/UsuarioService.java
+++ b/CrDuels/src/main/java/com/crduels/service/UsuarioService.java
@@ -17,6 +17,13 @@ public class UsuarioService {
     }
 
     public Usuario registrarUsuario(Usuario usuario) {
+        if (usuarioRepository.existsByEmail(usuario.getEmail())) {
+            throw new IllegalArgumentException("El email ya está registrado");
+        }
+        if (usuarioRepository.existsByTelefono(usuario.getTelefono())) {
+            throw new IllegalArgumentException("El teléfono ya está registrado");
+        }
+
         return usuarioRepository.save(usuario);
     }
 


### PR DESCRIPTION
## Summary
- avoid storing duplicate email or phone numbers by validating in `UsuarioService`
- handle validation failures in the controller and return HTTP 201 on success

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_6853200772a8832d83f4411d32790546