### PR TITLE
Add duplicate email/phone checks in user service

### DIFF
--- a/CrDuels/src/main/java/com/crduels/exception/DuplicateUserException.java
+++ b/CrDuels/src/main/java/com/crduels/exception/DuplicateUserException.java
@@ -1,0 +1,11 @@
+package com.crduels.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.CONFLICT)
+public class DuplicateUserException extends RuntimeException {
+    public DuplicateUserException(String message) {
+        super(message);
+    }
+}

--- a/CrDuels/src/main/java/com/crduels/service/UsuarioService.java
+++ b/CrDuels/src/main/java/com/crduels/service/UsuarioService.java
@@ -2,6 +2,7 @@ package com.crduels.service;
 
 import com.crduels.entity.Usuario;
 import com.crduels.repository.UsuarioRepository;
+import com.crduels.exception.DuplicateUserException;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
@@ -17,6 +18,12 @@ public class UsuarioService {
     }
 
     public Usuario registrarUsuario(Usuario usuario) {
+        if (usuarioRepository.existsByEmail(usuario.getEmail())) {
+            throw new DuplicateUserException("El email ya está registrado");
+        }
+        if (usuarioRepository.existsByTelefono(usuario.getTelefono())) {
+            throw new DuplicateUserException("El teléfono ya está registrado");
+        }
         return usuarioRepository.save(usuario);
     }
 


### PR DESCRIPTION
## Summary
- add `DuplicateUserException` annotated with `@ResponseStatus(HttpStatus.CONFLICT)`
- validate unique email and phone when registering a user

## Testing
- `mvn -q -f pom.xml test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_685323b2a128832dbfe0ebda8ed83cd6