### PR TITLE
Read datasource creds from env

### DIFF
--- a/CrDuels/src/main/resources/application.properties
+++ b/CrDuels/src/main/resources/application.properties
@@ -1,8 +1,8 @@
 server.port=8080
 
 spring.datasource.url=jdbc:postgresql://localhost:5432/crduels?connectTimeout=10&sslmode=prefer
-spring.datasource.username=postgres
-spring.datasource.password=Dj191919
+spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
+spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
 spring.datasource.driver-class-name=org.postgresql.Driver
 
 spring.jpa.hibernate.ddl-auto=update

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # CRduels
 apuestas clash
+
+## Environment variables
+
+The application expects the database credentials to be provided through the following environment variables:
+
+* `SPRING_DATASOURCE_USERNAME` - database username
+* `SPRING_DATASOURCE_PASSWORD` - database password


### PR DESCRIPTION
## Summary
- read datasource username and password from environment variables
- document required environment variables

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68532714c814832da463746185eefa50