### PR TITLE
Fix validation imports and regex

### DIFF
--- a/CrDuels/src/main/java/com/crduels/domain/model/Usuario.java
+++ b/CrDuels/src/main/java/com/crduels/domain/model/Usuario.java
@@ -5,7 +5,11 @@ import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
 
 import jakarta.persistence.*;
-import jakarta.validation.constraints.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.DecimalMin;
 import java.math.BigDecimal;
 import java.util.UUID;
 
@@ -44,7 +48,10 @@ public class Usuario {
     @Column(name = "tag_clash", unique = true)
     private String tagClash;
 
-    @Pattern(regexp = "^(https://link\\.clashroyale\\.com/invite/friend\?tag=.*)?$", message = "Enlace de amistad inválido")
+    @Pattern(
+        regexp = "^(https://link\\.clashroyale\\.com/invite/friend\\?tag=[A-Z0-9]+)?$",
+        message = "Enlace de amistad inválido"
+    )
     @Column(name = "link_amistad")
     private String linkAmistad;
 


### PR DESCRIPTION
## Summary
- replace wildcard validation imports with explicit ones
- correct friendship link regex

## Testing
- `mvn -q -f CrDuels/pom.xml test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68533784e2a0832dbb3f9b955a3bb8b7