### PR TITLE
Add Apuesta entity

### DIFF
--- a/CrDuels/src/main/java/com/crduels/domain/model/Apuesta.java
+++ b/CrDuels/src/main/java/com/crduels/domain/model/Apuesta.java
@@ -1,0 +1,50 @@
+package com.crduels.domain.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "apuestas")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Apuesta {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO, generator = "UUID")
+    @org.hibernate.annotations.GenericGenerator(
+            name = "UUID",
+            strategy = "org.hibernate.id.UUIDGenerator"
+    )
+    @Column(columnDefinition = "uuid", updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(name = "jugador1_id", columnDefinition = "uuid", nullable = false)
+    private UUID jugador1Id;
+
+    @Column(name = "jugador2_id", columnDefinition = "uuid", nullable = false)
+    private UUID jugador2Id;
+
+    @Column(nullable = false)
+    private BigDecimal monto;
+
+    @Column(name = "modo_juego", nullable = false)
+    private String modoJuego;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private EstadoApuesta estado;
+
+    @Column(name = "creado_en", nullable = false)
+    private LocalDateTime creadoEn;
+}

--- a/CrDuels/src/main/java/com/crduels/domain/model/EstadoApuesta.java
+++ b/CrDuels/src/main/java/com/crduels/domain/model/EstadoApuesta.java
@@ -1,0 +1,8 @@
+package com.crduels.domain.model;
+
+public enum EstadoApuesta {
+    PENDIENTE,
+    EN_PROGRESO,
+    FINALIZADA,
+    CANCELADA
+}


### PR DESCRIPTION
## Summary
- add `Apuesta` JPA entity with Lombok annotations
- define `EstadoApuesta` enum

## Testing
- `mvn -q test -f CrDuels/pom.xml` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_685344676030832d84b44d8ab06fd7e9