### PR TITLE
Add mapper and response DTO for apuestas

### DIFF
--- a/CrDuels/src/main/java/com/crduels/application/dto/ApuestaResponseDto.java
+++ b/CrDuels/src/main/java/com/crduels/application/dto/ApuestaResponseDto.java
@@ -1,0 +1,24 @@
+package com.crduels.application.dto;
+
+import com.crduels.domain.model.EstadoApuesta;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * DTO para responder con la información de una apuesta.
+ */
+@Getter
+@Setter
+@Builder
+public class ApuestaResponseDto {
+    private UUID id;
+    private BigDecimal monto;
+    private String modoJuego;
+    private EstadoApuesta estado;
+    private LocalDateTime creadoEn;
+}

--- a/CrDuels/src/main/java/com/crduels/application/mapper/ApuestaMapper.java
+++ b/CrDuels/src/main/java/com/crduels/application/mapper/ApuestaMapper.java
@@ -1,0 +1,12 @@
+package com.crduels.application.mapper;
+
+import com.crduels.application.dto.ApuestaRequestDto;
+import com.crduels.application.dto.ApuestaResponseDto;
+import com.crduels.domain.model.Apuesta;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface ApuestaMapper {
+    Apuesta toEntity(ApuestaRequestDto dto);
+    ApuestaResponseDto toDto(Apuesta entity);
+}


### PR DESCRIPTION
## Summary
- add `ApuestaResponseDto` for returning bet info
- create `ApuestaMapper` interface to map between request/response and entity

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685347078c88832da014525b525309ba