### PR TITLE
Implement betting service and endpoints

### DIFF
--- a/CrDuels/src/main/java/com/crduels/application/service/ApuestaService.java
+++ b/CrDuels/src/main/java/com/crduels/application/service/ApuestaService.java
@@ -1,0 +1,49 @@
+package com.crduels.application.service;
+
+import com.crduels.application.dto.ApuestaRequestDto;
+import com.crduels.application.dto.ApuestaResponseDto;
+import com.crduels.application.mapper.ApuestaMapper;
+import com.crduels.domain.model.Apuesta;
+import com.crduels.domain.model.EstadoApuesta;
+import com.crduels.infrastructure.repository.ApuestaRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+public class ApuestaService {
+
+    private final ApuestaRepository apuestaRepository;
+    private final ApuestaMapper apuestaMapper;
+
+    public ApuestaService(ApuestaRepository apuestaRepository, ApuestaMapper apuestaMapper) {
+        this.apuestaRepository = apuestaRepository;
+        this.apuestaMapper = apuestaMapper;
+    }
+
+    public ApuestaResponseDto crearApuesta(ApuestaRequestDto dto) {
+        Apuesta apuesta = apuestaMapper.toEntity(dto);
+        apuesta.setEstado(EstadoApuesta.PENDIENTE);
+        apuesta.setCreadoEn(LocalDateTime.now());
+        Apuesta saved = apuestaRepository.save(apuesta);
+        return apuestaMapper.toDto(saved);
+    }
+
+    public List<ApuestaResponseDto> listarPendientesPorModo(String modoJuego) {
+        return apuestaRepository.findByEstado(EstadoApuesta.PENDIENTE).stream()
+                .filter(a -> a.getModoJuego().equalsIgnoreCase(modoJuego))
+                .map(apuestaMapper::toDto)
+                .collect(Collectors.toList());
+    }
+
+    public ApuestaResponseDto cambiarEstado(UUID id, EstadoApuesta estado) {
+        Apuesta apuesta = apuestaRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Apuesta no encontrada"));
+        apuesta.setEstado(estado);
+        Apuesta saved = apuestaRepository.save(apuesta);
+        return apuestaMapper.toDto(saved);
+    }
+}

--- a/CrDuels/src/main/java/com/crduels/infrastructure/controller/ApuestaController.java
+++ b/CrDuels/src/main/java/com/crduels/infrastructure/controller/ApuestaController.java
@@ -1,0 +1,42 @@
+package com.crduels.infrastructure.controller;
+
+import com.crduels.application.dto.ApuestaRequestDto;
+import com.crduels.application.dto.ApuestaResponseDto;
+import com.crduels.application.service.ApuestaService;
+import com.crduels.domain.model.EstadoApuesta;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/apuestas")
+public class ApuestaController {
+
+    private final ApuestaService apuestaService;
+
+    public ApuestaController(ApuestaService apuestaService) {
+        this.apuestaService = apuestaService;
+    }
+
+    @PostMapping
+    public ResponseEntity<ApuestaResponseDto> crear(@RequestBody ApuestaRequestDto dto) {
+        ApuestaResponseDto response = apuestaService.crearApuesta(dto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping("/pendientes")
+    public ResponseEntity<List<ApuestaResponseDto>> listarPendientes(@RequestParam("modo") String modo) {
+        List<ApuestaResponseDto> lista = apuestaService.listarPendientesPorModo(modo);
+        return ResponseEntity.ok(lista);
+    }
+
+    @PutMapping("/{id}/estado")
+    public ResponseEntity<ApuestaResponseDto> cambiarEstado(@PathVariable UUID id,
+                                                            @RequestParam("estado") EstadoApuesta estado) {
+        ApuestaResponseDto response = apuestaService.cambiarEstado(id, estado);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/CrDuels/src/main/java/com/crduels/infrastructure/repository/ApuestaRepository.java
+++ b/CrDuels/src/main/java/com/crduels/infrastructure/repository/ApuestaRepository.java
@@ -1,0 +1,12 @@
+package com.crduels.infrastructure.repository;
+
+import com.crduels.domain.model.Apuesta;
+import com.crduels.domain.model.EstadoApuesta;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface ApuestaRepository extends JpaRepository<Apuesta, UUID> {
+    List<Apuesta> findByEstado(EstadoApuesta estado);
+}


### PR DESCRIPTION
## Summary
- add ApuestaRepository for JPA access
- implement ApuestaService with creation/list/update methods
- expose new endpoints in ApuestaController

## Testing
- `mvn -q -f CrDuels/pom.xml test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685348adaee0832d8024f4b10ff112e3