### PR TITLE
Fix ApuestaResponseDto constructors

### DIFF
--- a/CrDuels/src/main/java/com/crduels/application/dto/ApuestaResponseDto.java
+++ b/CrDuels/src/main/java/com/crduels/application/dto/ApuestaResponseDto.java
@@ -1,9 +1,9 @@
 package com.crduels.application.dto;
 
 import com.crduels.domain.model.EstadoApuesta;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -12,9 +12,9 @@ import java.util.UUID;
 /**
  * DTO para responder con la información de una apuesta.
  */
-@Getter
-@Setter
-@Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class ApuestaResponseDto {
     private UUID id;
     private BigDecimal monto;


### PR DESCRIPTION
## Summary
- add Lombok `@NoArgsConstructor` and `@AllArgsConstructor`
- remove builder pattern to let MapStruct instantiate `ApuestaResponseDto`

## Testing
- `mvn -q -f CrDuels/pom.xml test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68534bf8e0e0832d8dfad1b6bbcca0a3