### PR TITLE
Add Transaccion entity

### DIFF
--- a/CrDuels/src/main/java/com/crduels/domain/model/EstadoTransaccion.java
+++ b/CrDuels/src/main/java/com/crduels/domain/model/EstadoTransaccion.java
@@ -1,0 +1,7 @@
+package com.crduels.domain.model;
+
+public enum EstadoTransaccion {
+    PENDIENTE,
+    COMPLETADA,
+    CANCELADA
+}

--- a/CrDuels/src/main/java/com/crduels/domain/model/TipoTransaccion.java
+++ b/CrDuels/src/main/java/com/crduels/domain/model/TipoTransaccion.java
@@ -1,0 +1,6 @@
+package com.crduels.domain.model;
+
+public enum TipoTransaccion {
+    DEPOSITO,
+    RETIRO
+}

--- a/CrDuels/src/main/java/com/crduels/domain/model/Transaccion.java
+++ b/CrDuels/src/main/java/com/crduels/domain/model/Transaccion.java
@@ -1,0 +1,48 @@
+package com.crduels.domain.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "transacciones")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Transaccion {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO, generator = "UUID")
+    @org.hibernate.annotations.GenericGenerator(
+            name = "UUID",
+            strategy = "org.hibernate.id.UUIDGenerator"
+    )
+    @Column(columnDefinition = "uuid", updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(name = "usuario_id", columnDefinition = "uuid", nullable = false)
+    private UUID usuarioId;
+
+    @Column(nullable = false)
+    private BigDecimal monto;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private TipoTransaccion tipo;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private EstadoTransaccion estado;
+
+    @Column(name = "creado_en", nullable = false)
+    private LocalDateTime creadoEn;
+}


### PR DESCRIPTION
## Summary
- create `Transaccion` domain model with JPA annotations
- add `TipoTransaccion` and `EstadoTransaccion` enums

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685352003540832da0dfa7737f27df42