### PR TITLE
Implement matchmaking result DTO and service

### DIFF
--- a/CrDuels/src/main/java/com/crduels/application/dto/MatchResultDto.java
+++ b/CrDuels/src/main/java/com/crduels/application/dto/MatchResultDto.java
@@ -1,0 +1,21 @@
+package com.crduels.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+/**
+ * DTO que representa el resultado de un emparejamiento entre dos apuestas.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MatchResultDto {
+    private UUID apuesta1Id;
+    private UUID apuesta2Id;
+    private BigDecimal monto;
+    private String modoJuego;
+}

--- a/CrDuels/src/main/java/com/crduels/application/service/MatchmakingService.java
+++ b/CrDuels/src/main/java/com/crduels/application/service/MatchmakingService.java
@@ -1,28 +1,30 @@
 package com.crduels.application.service;
 
+import com.crduels.application.dto.MatchResultDto;
 import com.crduels.domain.model.Apuesta;
 import com.crduels.domain.model.EstadoApuesta;
 import com.crduels.infrastructure.repository.ApuestaRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.math.BigDecimal;
 import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
+@RequiredArgsConstructor
 public class MatchmakingService {
 
     private final ApuestaRepository apuestaRepository;
-
-    public MatchmakingService(ApuestaRepository apuestaRepository) {
-        this.apuestaRepository = apuestaRepository;
-    }
 
     /**
      * Ejecuta el proceso de emparejamiento de apuestas. Se buscan todas las
      * apuestas con estado PENDIENTE y se agrupan por monto y modo de juego.
      * Para cada grupo se toman pares de apuestas y se marcan como EMPAREJADA.
      */
-    public void ejecutarMatchmaking() {
+    public List<MatchResultDto> ejecutarMatchmaking() {
+        List<MatchResultDto> resultados = new ArrayList<>();
+
         // 1. Obtener todas las apuestas pendientes
         List<Apuesta> pendientes = apuestaRepository.findByEstado(EstadoApuesta.PENDIENTE);
 
@@ -39,10 +41,20 @@ public class MatchmakingService {
                 // 4. Cambiar estado y guardar
                 a1.setEstado(EstadoApuesta.EMPAREJADA);
                 a2.setEstado(EstadoApuesta.EMPAREJADA);
-                apuestaRepository.save(a1);
-                apuestaRepository.save(a2);
+                // opcional: registrar hora de emparejamiento si existiera campo
+
+                apuestaRepository.saveAll(Arrays.asList(a1, a2));
+
+                resultados.add(new MatchResultDto(
+                        a1.getId(),
+                        a2.getId(),
+                        a1.getMonto(),
+                        a1.getModoJuego()
+                ));
             }
         }
+
+        return resultados;
     }
 
     /**

--- a/CrDuels/src/test/java/com/crduels/service/MatchmakingServiceTest.java
+++ b/CrDuels/src/test/java/com/crduels/service/MatchmakingServiceTest.java
@@ -1,0 +1,61 @@
+package com.crduels.service;
+
+import com.crduels.application.dto.MatchResultDto;
+import com.crduels.application.service.MatchmakingService;
+import com.crduels.domain.model.Apuesta;
+import com.crduels.domain.model.EstadoApuesta;
+import com.crduels.infrastructure.repository.ApuestaRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@Import(MatchmakingService.class)
+class MatchmakingServiceTest {
+
+    @Autowired
+    private MatchmakingService matchmakingService;
+
+    @Autowired
+    private ApuestaRepository apuestaRepository;
+
+    private Apuesta crearApuesta(BigDecimal monto, String modo) {
+        return Apuesta.builder()
+                .jugador1Id(UUID.randomUUID())
+                .jugador2Id(UUID.randomUUID())
+                .monto(monto)
+                .modoJuego(modo)
+                .estado(EstadoApuesta.PENDIENTE)
+                .creadoEn(LocalDateTime.now())
+                .build();
+    }
+
+    @Test
+    void ejecutarMatchmaking_emparejaPendientes() {
+        Apuesta a1 = crearApuesta(new BigDecimal("5"), "1v1");
+        Apuesta a2 = crearApuesta(new BigDecimal("5"), "1v1");
+        apuestaRepository.save(a1);
+        apuestaRepository.save(a2);
+        apuestaRepository.flush();
+
+        List<MatchResultDto> resultados = matchmakingService.ejecutarMatchmaking();
+        apuestaRepository.flush();
+
+        assertEquals(1, resultados.size());
+        assertEquals(EstadoApuesta.EMPAREJADA, apuestaRepository.findById(a1.getId()).get().getEstado());
+        assertEquals(EstadoApuesta.EMPAREJADA, apuestaRepository.findById(a2.getId()).get().getEstado());
+        MatchResultDto r = resultados.get(0);
+        assertEquals(a1.getId(), r.getApuesta1Id());
+        assertEquals(a2.getId(), r.getApuesta2Id());
+        assertEquals(new BigDecimal("5"), r.getMonto());
+        assertEquals("1v1", r.getModoJuego());
+    }
+}


### PR DESCRIPTION
## Summary
- implement matchmaking logic returning a list of `MatchResultDto`
- use Lombok `@RequiredArgsConstructor` for `MatchmakingService`
- add new `MatchResultDto` DTO
- add unit test for the matchmaking logic

## Testing
- `mvn -q test -f CrDuels/pom.xml` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_68535b8fb89c832d92c4dee8842e54ef