### PR TITLE
Add Matchmaking controller and DTO

### DIFF
--- a/CrDuels/src/main/java/com/crduels/application/dto/MatchResultDto.java
+++ b/CrDuels/src/main/java/com/crduels/application/dto/MatchResultDto.java
@@ -1,0 +1,21 @@
+package com.crduels.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+/**
+ * DTO para devolver el resultado del emparejamiento de apuestas.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MatchResultDto {
+    private UUID apuesta1Id;
+    private UUID apuesta2Id;
+    private BigDecimal monto;
+    private String modoJuego;
+}

--- a/CrDuels/src/main/java/com/crduels/application/service/MatchmakingService.java
+++ b/CrDuels/src/main/java/com/crduels/application/service/MatchmakingService.java
@@ -1,5 +1,6 @@
 package com.crduels.application.service;
 
+import com.crduels.application.dto.MatchResultDto;
 import com.crduels.domain.model.Apuesta;
 import com.crduels.domain.model.EstadoApuesta;
 import com.crduels.infrastructure.repository.ApuestaRepository;
@@ -22,7 +23,7 @@ public class MatchmakingService {
      * apuestas con estado PENDIENTE y se agrupan por monto y modo de juego.
      * Para cada grupo se toman pares de apuestas y se marcan como EMPAREJADA.
      */
-    public void ejecutarMatchmaking() {
+    public List<MatchResultDto> ejecutarMatchmaking() {
         // 1. Obtener todas las apuestas pendientes
         List<Apuesta> pendientes = apuestaRepository.findByEstado(EstadoApuesta.PENDIENTE);
 
@@ -31,6 +32,7 @@ public class MatchmakingService {
                 .collect(Collectors.groupingBy(a -> new Key(a.getMonto(), a.getModoJuego())));
 
         // 3. Procesar cada grupo buscando pares
+        List<MatchResultDto> resultados = new ArrayList<>();
         for (List<Apuesta> grupo : grupos.values()) {
             for (int i = 0; i + 1 < grupo.size(); i += 2) {
                 Apuesta a1 = grupo.get(i);
@@ -41,8 +43,12 @@ public class MatchmakingService {
                 a2.setEstado(EstadoApuesta.EMPAREJADA);
                 apuestaRepository.save(a1);
                 apuestaRepository.save(a2);
+
+                resultados.add(new MatchResultDto(a1.getId(), a2.getId(), a1.getMonto(), a1.getModoJuego()));
             }
         }
+
+        return resultados;
     }
 
     /**

--- a/CrDuels/src/main/java/com/crduels/infrastructure/controller/MatchmakingController.java
+++ b/CrDuels/src/main/java/com/crduels/infrastructure/controller/MatchmakingController.java
@@ -1,0 +1,27 @@
+package com.crduels.infrastructure.controller;
+
+import com.crduels.application.dto.MatchResultDto;
+import com.crduels.application.service.MatchmakingService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/matchmaking")
+public class MatchmakingController {
+
+    private final MatchmakingService matchmakingService;
+
+    public MatchmakingController(MatchmakingService matchmakingService) {
+        this.matchmakingService = matchmakingService;
+    }
+
+    @PostMapping
+    public ResponseEntity<List<MatchResultDto>> ejecutarMatch() {
+        List<MatchResultDto> resultados = matchmakingService.ejecutarMatchmaking();
+        return ResponseEntity.ok(resultados);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `MatchResultDto` for matchmaking results
- update `MatchmakingService` to return match results
- add `MatchmakingController` REST endpoint

## Testing
- `mvn -q test -f CrDuels/pom.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68535ba89b08832dbb225fd33c9ee4d6