### PR TITLE
Add Swagger UI dependency

### DIFF
--- a/CrDuels/pom.xml
+++ b/CrDuels/pom.xml
@@ -85,6 +85,12 @@
             <version>1.5.5.Final</version>
             <scope>provided</scope>
         </dependency>
+        <!-- Documentación Swagger generada automáticamente -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.5.0</version>
+        </dependency>
 <!-- Dependencias de prueba -->
 <!-- Testing -->
 <dependency>

--- a/README.md
+++ b/README.md
@@ -46,3 +46,11 @@ curl -X POST http://localhost:8080/api/usuarios/registro \
 ```bash
 curl http://localhost:8080/api/usuarios/<uuid>
 ```
+
+### API documentation
+
+When the server is running you can explore the REST contracts using Swagger UI at:
+
+```text
+http://localhost:8080/swagger-ui/index.html
+```


### PR DESCRIPTION
## Summary
- add springdoc dependency for automatic Swagger UI generation
- document Swagger endpoint in README

## Testing
- `mvn -q test -f CrDuels/pom.xml` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_68536455ffc4832dbfb2878ea60fcc74