### PR TITLE
Integrate WhatsApp webhook

### DIFF
--- a/CrDuels/src/main/java/com/crduels/application/dto/RegistroWhatsAppDto.java
+++ b/CrDuels/src/main/java/com/crduels/application/dto/RegistroWhatsAppDto.java
@@ -1,0 +1,16 @@
+package com.crduels.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Datos para registrar un usuario a través de WhatsApp.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RegistroWhatsAppDto {
+    private String nombre;
+    private String tagClash;
+}

--- a/CrDuels/src/main/java/com/crduels/application/service/ApuestaService.java
+++ b/CrDuels/src/main/java/com/crduels/application/service/ApuestaService.java
@@ -36,12 +36,18 @@ public class ApuestaService {
 
         if (apuesta.getJugador1() != null) {
             usuarioRepository.findById(apuesta.getJugador1().getId()).ifPresent(u -> {
+                if (u.getSaldo().compareTo(apuesta.getMonto()) < 0) {
+                    throw new IllegalArgumentException("Saldo insuficiente para el jugador");
+                }
                 u.setSaldo(u.getSaldo().subtract(apuesta.getMonto()));
                 usuarioRepository.save(u);
             });
         }
         if (apuesta.getJugador2() != null) {
             usuarioRepository.findById(apuesta.getJugador2().getId()).ifPresent(u -> {
+                if (u.getSaldo().compareTo(apuesta.getMonto()) < 0) {
+                    throw new IllegalArgumentException("Saldo insuficiente para el jugador");
+                }
                 u.setSaldo(u.getSaldo().subtract(apuesta.getMonto()));
                 usuarioRepository.save(u);
             });

--- a/CrDuels/src/main/java/com/crduels/application/service/UsuarioService.java
+++ b/CrDuels/src/main/java/com/crduels/application/service/UsuarioService.java
@@ -1,6 +1,7 @@
 package com.crduels.application.service;
 
 import com.crduels.application.dto.UsuarioDto;
+import com.crduels.application.dto.RegistroWhatsAppDto;
 import com.crduels.application.mapper.UsuarioMapper;
 import com.crduels.application.exception.DuplicateUserException;
 import com.crduels.domain.model.Usuario;
@@ -37,5 +38,15 @@ public class UsuarioService {
 
     public Optional<UsuarioDto> obtenerPorId(UUID id) {
         return usuarioRepository.findById(id).map(usuarioMapper::toDto);
+    }
+
+    public Usuario registrarDesdeWhatsapp(String telefono, RegistroWhatsAppDto dto) {
+        return usuarioRepository.findByTelefono(telefono).orElseGet(() -> {
+            Usuario nuevo = new Usuario();
+            nuevo.setNombre(dto.getNombre());
+            nuevo.setTelefono(telefono);
+            nuevo.setTagClash(dto.getTagClash());
+            return usuarioRepository.save(nuevo);
+        });
     }
 }

--- a/CrDuels/src/main/java/com/crduels/application/service/WhatsappService.java
+++ b/CrDuels/src/main/java/com/crduels/application/service/WhatsappService.java
@@ -1,0 +1,50 @@
+package com.crduels.application.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+/**
+ * Servicio para enviar mensajes a través de la API de WhatsApp Business.
+ */
+@Service
+public class WhatsappService {
+
+    @Value("${WHATSAPP_API_TOKEN}")
+    private String apiToken;
+
+    @Value("${WHATSAPP_PHONE_NUMBER_ID}")
+    private String phoneNumberId;
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    public void enviarMensajeTexto(String waId, String mensaje) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(apiToken);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        Map<String, Object> payload = Map.of(
+                "messaging_product", "whatsapp",
+                "to", waId,
+                "type", "text",
+                "text", Map.of("body", mensaje)
+        );
+
+        HttpEntity<Map<String, Object>> entity = new HttpEntity<>(payload, headers);
+        String url = "https://graph.facebook.com/v19.0/" + phoneNumberId + "/messages";
+        restTemplate.postForEntity(url, entity, String.class);
+    }
+
+    public String generarLinkClash(String tag) {
+        if (tag == null) {
+            return "";
+        }
+        String clean = tag.replace("#", "");
+        return "https://link.clashroyale.com/invite/friend?tag=" + clean;
+    }
+}

--- a/CrDuels/src/main/java/com/crduels/infrastructure/controller/WhatsappWebhookController.java
+++ b/CrDuels/src/main/java/com/crduels/infrastructure/controller/WhatsappWebhookController.java
@@ -1,0 +1,46 @@
+package com.crduels.infrastructure.controller;
+
+import com.crduels.application.dto.RegistroWhatsAppDto;
+import com.crduels.application.service.UsuarioService;
+import com.crduels.application.service.WhatsappService;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Webhook público para recibir mensajes de WhatsApp.
+ */
+@RestController
+@RequestMapping("/api/webhook")
+public class WhatsappWebhookController {
+
+    private final UsuarioService usuarioService;
+    private final WhatsappService whatsappService;
+
+    public WhatsappWebhookController(UsuarioService usuarioService, WhatsappService whatsappService) {
+        this.usuarioService = usuarioService;
+        this.whatsappService = whatsappService;
+    }
+
+    @PostMapping("/whatsapp")
+    public ResponseEntity<Void> recibirMensaje(@RequestBody JsonNode body) {
+        JsonNode entry = body.path("entry").get(0);
+        JsonNode change = entry.path("changes").get(0);
+        JsonNode value = change.path("value");
+        JsonNode contact = value.path("contacts").get(0);
+        String waId = contact.path("wa_id").asText();
+        String nombre = contact.path("profile").path("name").asText();
+        JsonNode message = value.path("messages").get(0);
+        String text = message.path("text").path("body").asText();
+
+        RegistroWhatsAppDto dto = new RegistroWhatsAppDto(nombre, text);
+        var usuario = usuarioService.registrarDesdeWhatsapp(waId, dto);
+
+        String saludo = "¡Hola " + usuario.getNombre() + "! Para comenzar, necesitas hacer un depósito.";
+        whatsappService.enviarMensajeTexto(waId, saludo);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/CrDuels/src/main/java/com/crduels/infrastructure/repository/UsuarioRepository.java
+++ b/CrDuels/src/main/java/com/crduels/infrastructure/repository/UsuarioRepository.java
@@ -7,4 +7,5 @@ import java.util.UUID;
 public interface UsuarioRepository extends JpaRepository<Usuario, UUID> {
     boolean existsByEmail(String email);
     boolean existsByTelefono(String telefono);
+    java.util.Optional<Usuario> findByTelefono(String telefono);
 }

--- a/CrDuels/src/main/resources/application.properties
+++ b/CrDuels/src/main/resources/application.properties
@@ -9,3 +9,7 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
+
+# Integración con WhatsApp
+WHATSAPP_API_TOKEN=${WHATSAPP_API_TOKEN}
+WHATSAPP_PHONE_NUMBER_ID=${WHATSAPP_PHONE_NUMBER_ID}


### PR DESCRIPTION
## Summary
- add DTO for WhatsApp registration
- send WhatsApp messages via new service
- create public WhatsApp webhook controller
- validate user balance when creating a bet
- add phone lookup in `UsuarioRepository`
- expose WhatsApp environment variables

## Testing
- `mvn -q -f CrDuels/pom.xml -DskipTests=false test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_6854528a46cc832d9abb04d2f736a5c7