### PR TITLE
Add WhatsApp webhook verification

### DIFF
--- a/CrDuels/src/main/java/com/crduels/infrastructure/controller/WhatsappWebhookController.java
+++ b/CrDuels/src/main/java/com/crduels/infrastructure/controller/WhatsappWebhookController.java
@@ -4,10 +4,13 @@ import com.crduels.application.dto.RegistroWhatsAppDto;
 import com.crduels.application.service.UsuarioService;
 import com.crduels.application.service.WhatsappService;
 import com.fasterxml.jackson.databind.JsonNode;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -23,6 +26,16 @@ public class WhatsappWebhookController {
     public WhatsappWebhookController(UsuarioService usuarioService, WhatsappService whatsappService) {
         this.usuarioService = usuarioService;
         this.whatsappService = whatsappService;
+    }
+
+    @GetMapping("/whatsapp")
+    public ResponseEntity<String> verificarWebhook(@RequestParam("hub.mode") String mode,
+                                                   @RequestParam("hub.verify_token") String token,
+                                                   @RequestParam("hub.challenge") String challenge) {
+        if ("Dj191919CrDuels".equals(token)) {
+            return ResponseEntity.ok(challenge);
+        }
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body("Token inválido");
     }
 
     @PostMapping("/whatsapp")


### PR DESCRIPTION
## Summary
- add GET endpoint to verify WhatsApp webhook

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_685465281eec832d8ea4866d621e5ee5