### PR TITLE
Add WhatsApp interactive menus and relay feature

### DIFF
--- a/CrDuels/src/main/java/com/crduels/application/service/WhatsappService.java
+++ b/CrDuels/src/main/java/com/crduels/application/service/WhatsappService.java
@@ -7,6 +7,7 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -55,5 +56,127 @@ public class WhatsappService {
         }
         String clean = tag.replace("#", "");
         return "https://link.clashroyale.com/invite/friend?tag=" + clean;
+    }
+
+    /**
+     * Envía un menú de registro con un solo botón para iniciar el proceso.
+     */
+    public void enviarMenuRegistro(String waId) {
+        if (apiToken.isBlank() || phoneNumberId.isBlank()) {
+            return;
+        }
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(apiToken);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        Map<String, Object> payload = Map.of(
+                "messaging_product", "whatsapp",
+                "to", waId,
+                "type", "interactive",
+                "interactive", Map.of(
+                        "type", "button",
+                        "body", Map.of("text", "¡Hola! Para comenzar a usar el sistema, por favor regístrate."),
+                        "action", Map.of("buttons", List.of(
+                                Map.of(
+                                        "type", "reply",
+                                        "reply", Map.of(
+                                                "id", "REGISTRARSE",
+                                                "title", "📝 Registrarse"
+                                        )
+                                )
+                        ))
+                )
+        );
+
+        HttpEntity<Map<String, Object>> entity = new HttpEntity<>(payload, headers);
+        String url = "https://graph.facebook.com/v19.0/" + phoneNumberId + "/messages";
+        restTemplate.postForEntity(url, entity, String.class);
+    }
+
+    /**
+     * Envía opciones de recarga de saldo en un menú interactivo.
+     */
+    public void enviarMenuRecarga(String waId) {
+        if (apiToken.isBlank() || phoneNumberId.isBlank()) {
+            return;
+        }
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(apiToken);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        Map<String, Object> payload = Map.of(
+                "messaging_product", "whatsapp",
+                "to", waId,
+                "type", "interactive",
+                "interactive", Map.of(
+                        "type", "button",
+                        "body", Map.of("text", "Necesitas recargar saldo para poder jugar. Elige un monto:"),
+                        "action", Map.of("buttons", List.of(
+                                Map.of(
+                                        "type", "reply",
+                                        "reply", Map.of("id", "RECARGA_6000", "title", "💰 Recargar 6000")
+                                ),
+                                Map.of(
+                                        "type", "reply",
+                                        "reply", Map.of("id", "RECARGA_12000", "title", "💰 Recargar 12000")
+                                ),
+                                Map.of(
+                                        "type", "reply",
+                                        "reply", Map.of("id", "RECARGA_18000", "title", "💰 Recargar 18000")
+                                )
+                        ))
+                )
+        );
+
+        HttpEntity<Map<String, Object>> entity = new HttpEntity<>(payload, headers);
+        String url = "https://graph.facebook.com/v19.0/" + phoneNumberId + "/messages";
+        restTemplate.postForEntity(url, entity, String.class);
+    }
+
+    /**
+     * Envía el menú principal con las acciones disponibles para el usuario.
+     */
+    public void enviarMenuPrincipal(String waId) {
+        if (apiToken.isBlank() || phoneNumberId.isBlank()) {
+            return;
+        }
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(apiToken);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        Map<String, Object> payload = Map.of(
+                "messaging_product", "whatsapp",
+                "to", waId,
+                "type", "interactive",
+                "interactive", Map.of(
+                        "type", "button",
+                        "body", Map.of("text", "¿Qué deseas hacer?"),
+                        "action", Map.of("buttons", List.of(
+                                Map.of(
+                                        "type", "reply",
+                                        "reply", Map.of("id", "BUSCAR_PARTIDA", "title", "⚔️ Buscar partida")
+                                ),
+                                Map.of(
+                                        "type", "reply",
+                                        "reply", Map.of("id", "RETIRAR_SALDO", "title", "Retirar saldo")
+                                ),
+                                Map.of(
+                                        "type", "reply",
+                                        "reply", Map.of("id", "MI_SALDO", "title", "Mi saldo")
+                                ),
+                                Map.of(
+                                        "type", "reply",
+                                        "reply", Map.of("id", "HISTORIAL", "title", "Historial de partidas")
+                                )
+                        ))
+                )
+        );
+
+        HttpEntity<Map<String, Object>> entity = new HttpEntity<>(payload, headers);
+        String url = "https://graph.facebook.com/v19.0/" + phoneNumberId + "/messages";
+        restTemplate.postForEntity(url, entity, String.class);
     }
 }

--- a/CrDuels/src/main/java/com/crduels/infrastructure/repository/PartidaRepository.java
+++ b/CrDuels/src/main/java/com/crduels/infrastructure/repository/PartidaRepository.java
@@ -2,10 +2,15 @@ package com.crduels.infrastructure.repository;
 
 import com.crduels.domain.model.Partida;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 import java.util.UUID;
 
 public interface PartidaRepository extends JpaRepository<Partida, UUID> {
     Optional<Partida> findByApuesta_Id(UUID apuestaId);
+
+    @Query("SELECT p FROM Partida p WHERE p.validada = false AND (p.apuesta.jugador1.telefono = :tel OR p.apuesta.jugador2.telefono = :tel)")
+    Optional<Partida> findActivaPorTelefono(@Param("tel") String telefono);
 }


### PR DESCRIPTION
## Summary
- add interactive menu helpers in `WhatsappService`
- allow querying current match by phone
- relay received messages to opponent when a match is active
- show appropriate menu depending on registration/saldo status

## Testing
- `mvn -q -DskipTests package -f pom.xml` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_6854889a9c28832d9467e21e6e653b06