### PR TITLE
Handle WhatsApp webhook generically

### DIFF
--- a/CrDuels/src/main/java/com/crduels/application/dto/WhatsappMessagesValueDto.java
+++ b/CrDuels/src/main/java/com/crduels/application/dto/WhatsappMessagesValueDto.java
@@ -1,0 +1,73 @@
+package com.crduels.application.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * DTO for the 'messages' value in the WhatsApp webhook.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class WhatsappMessagesValueDto {
+    @JsonProperty("messaging_product")
+    private String messagingProduct;
+    private Metadata metadata;
+    private List<Contact> contacts;
+    private List<Message> messages;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Metadata {
+        @JsonProperty("display_phone_number")
+        private String displayPhoneNumber;
+        @JsonProperty("phone_number_id")
+        private String phoneNumberId;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Contact {
+        private Profile profile;
+        @JsonProperty("wa_id")
+        private String waId;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Profile {
+        private String name;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Message {
+        private String from;
+        private String id;
+        private String timestamp;
+        private String type;
+        private Text text;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Text {
+        private String body;
+    }
+}

--- a/CrDuels/src/main/java/com/crduels/application/dto/WhatsappWebhookDto.java
+++ b/CrDuels/src/main/java/com/crduels/application/dto/WhatsappWebhookDto.java
@@ -1,0 +1,39 @@
+package com.crduels.application.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * Generic payload for WhatsApp webhook notifications.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class WhatsappWebhookDto {
+    private String object;
+    private List<EntryDto> entry;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class EntryDto {
+        private String id;
+        private List<ChangeDto> changes;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class ChangeDto {
+        private String field;
+        private JsonNode value;
+    }
+}


### PR DESCRIPTION
## Summary
- add DTOs to represent generic WhatsApp webhook payload and `messages` value
- map webhook request in `WhatsappWebhookController`
- trigger message handling when the `field` is `messages`

## Testing
- `mvn -q -f CrDuels/pom.xml test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68549f912cfc832da7fc67682b4c7509