### PR TITLE
Use Google ID as primary key for users

### DIFF
--- a/CrDuels/src/main/java/com/crduels/application/dto/ApuestaRequestDto.java
+++ b/CrDuels/src/main/java/com/crduels/application/dto/ApuestaRequestDto.java
@@ -3,7 +3,6 @@ package com.crduels.application.dto;
 import lombok.*;
 
 import java.math.BigDecimal;
-import java.util.UUID;
 
 /**
  * DTO para la creación de apuestas.
@@ -13,8 +12,8 @@ import java.util.UUID;
 @AllArgsConstructor
 @Builder
 public class ApuestaRequestDto {
-    private UUID jugador1Id;
-    private UUID jugador2Id;
+    private String jugador1Id;
+    private String jugador2Id;
     private BigDecimal monto;
     private String modoJuego;
 }

--- a/CrDuels/src/main/java/com/crduels/application/dto/PartidaRequestDto.java
+++ b/CrDuels/src/main/java/com/crduels/application/dto/PartidaRequestDto.java
@@ -13,6 +13,6 @@ import java.util.UUID;
 @Builder
 public class PartidaRequestDto {
     private UUID apuestaId;
-    private UUID ganadorId;
+    private String ganadorId;
     private String resultadoJson;
 }

--- a/CrDuels/src/main/java/com/crduels/application/dto/PartidaResponseDto.java
+++ b/CrDuels/src/main/java/com/crduels/application/dto/PartidaResponseDto.java
@@ -15,7 +15,7 @@ import java.util.UUID;
 public class PartidaResponseDto {
     private UUID id;
     private UUID apuestaId;
-    private UUID ganadorId;
+    private String ganadorId;
     private boolean validada;
     private LocalDateTime validadaEn;
 }

--- a/CrDuels/src/main/java/com/crduels/application/dto/TransaccionRequestDto.java
+++ b/CrDuels/src/main/java/com/crduels/application/dto/TransaccionRequestDto.java
@@ -4,14 +4,13 @@ import com.crduels.domain.model.TipoTransaccion;
 import lombok.*;
 
 import java.math.BigDecimal;
-import java.util.UUID;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class TransaccionRequestDto {
-    private UUID usuarioId;
+    private String usuarioId;
     private BigDecimal monto;
     private TipoTransaccion tipo;
 }

--- a/CrDuels/src/main/java/com/crduels/application/dto/TransaccionResponseDto.java
+++ b/CrDuels/src/main/java/com/crduels/application/dto/TransaccionResponseDto.java
@@ -9,7 +9,6 @@ import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
-import java.util.UUID;
 
 @Data
 @NoArgsConstructor
@@ -17,7 +16,7 @@ import java.util.UUID;
 @Builder
 public class TransaccionResponseDto {
     private UUID id;
-    private UUID usuarioId;
+    private String usuarioId;
     private BigDecimal monto;
     private TipoTransaccion tipo;
     private EstadoTransaccion estado;

--- a/CrDuels/src/main/java/com/crduels/application/dto/UsuarioDto.java
+++ b/CrDuels/src/main/java/com/crduels/application/dto/UsuarioDto.java
@@ -4,13 +4,14 @@ import lombok.*;
 import jakarta.validation.constraints.*;
 
 import java.math.BigDecimal;
-import java.util.UUID;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class UsuarioDto {
+    @NotBlank
+    private String googleId;
     @NotBlank(message = "El nombre es obligatorio")
     @Size(max = 100)
     private String nombre;

--- a/CrDuels/src/main/java/com/crduels/application/mapper/UsuarioMapper.java
+++ b/CrDuels/src/main/java/com/crduels/application/mapper/UsuarioMapper.java
@@ -12,6 +12,7 @@ public class UsuarioMapper {
             return null;
         }
         return UsuarioDto.builder()
+                .googleId(usuario.getId())
                 .nombre(usuario.getNombre())
                 .email(usuario.getEmail())
                 .telefono(usuario.getTelefono())
@@ -27,6 +28,7 @@ public class UsuarioMapper {
             return null;
         }
         Usuario usuario = new Usuario();
+        usuario.setId(dto.getGoogleId());
         usuario.setNombre(dto.getNombre());
         usuario.setEmail(dto.getEmail());
         usuario.setTelefono(dto.getTelefono());

--- a/CrDuels/src/main/java/com/crduels/application/service/TransaccionService.java
+++ b/CrDuels/src/main/java/com/crduels/application/service/TransaccionService.java
@@ -39,7 +39,7 @@ public class TransaccionService {
         return transaccionMapper.toDto(saved);
     }
 
-    public List<TransaccionResponseDto> listarPorUsuario(UUID usuarioId) {
+    public List<TransaccionResponseDto> listarPorUsuario(String usuarioId) {
         return transaccionRepository.findByUsuario_Id(usuarioId).stream()
                 .map(transaccionMapper::toDto)
                 .collect(Collectors.toList());

--- a/CrDuels/src/main/java/com/crduels/application/service/UsuarioService.java
+++ b/CrDuels/src/main/java/com/crduels/application/service/UsuarioService.java
@@ -8,7 +8,6 @@ import com.crduels.infrastructure.repository.UsuarioRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
-import java.util.UUID;
 
 @Service
 public class UsuarioService {
@@ -35,7 +34,7 @@ public class UsuarioService {
         return usuarioMapper.toDto(saved);
     }
 
-    public Optional<UsuarioDto> obtenerPorId(UUID id) {
+    public Optional<UsuarioDto> obtenerPorId(String id) {
         return usuarioRepository.findById(id).map(usuarioMapper::toDto);
     }
 

--- a/CrDuels/src/main/java/com/crduels/domain/model/Usuario.java
+++ b/CrDuels/src/main/java/com/crduels/domain/model/Usuario.java
@@ -6,7 +6,6 @@ import lombok.AllArgsConstructor;
 
 import jakarta.persistence.*;
 import java.math.BigDecimal;
-import java.util.UUID;
 
 @Entity
 @Table(name = "usuarios")
@@ -16,13 +15,8 @@ import java.util.UUID;
 public class Usuario {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO, generator = "UUID")
-    @org.hibernate.annotations.GenericGenerator(
-            name = "UUID",
-            strategy = "org.hibernate.id.UUIDGenerator"
-    )
-    @Column(columnDefinition = "uuid", updatable = false, nullable = false)
-    private UUID id;
+    @Column(name = "id", nullable = false, unique = true)
+    private String id;
 
     private String nombre;
 

--- a/CrDuels/src/main/java/com/crduels/infrastructure/controller/TransaccionController.java
+++ b/CrDuels/src/main/java/com/crduels/infrastructure/controller/TransaccionController.java
@@ -28,7 +28,7 @@ public class TransaccionController {
     }
 
     @GetMapping("/usuario/{id}")
-    public ResponseEntity<List<TransaccionResponseDto>> listarPorUsuario(@PathVariable("id") UUID usuarioId) {
+    public ResponseEntity<List<TransaccionResponseDto>> listarPorUsuario(@PathVariable("id") String usuarioId) {
         List<TransaccionResponseDto> lista = transaccionService.listarPorUsuario(usuarioId);
         return ResponseEntity.ok(lista);
     }

--- a/CrDuels/src/main/java/com/crduels/infrastructure/controller/UsuarioController.java
+++ b/CrDuels/src/main/java/com/crduels/infrastructure/controller/UsuarioController.java
@@ -8,7 +8,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/usuarios")
@@ -33,7 +32,7 @@ public class UsuarioController {
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<UsuarioDto> obtener(@PathVariable UUID id) {
+    public ResponseEntity<UsuarioDto> obtener(@PathVariable String id) {
         return usuarioService.obtenerPorId(id)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());

--- a/CrDuels/src/main/java/com/crduels/infrastructure/repository/TransaccionRepository.java
+++ b/CrDuels/src/main/java/com/crduels/infrastructure/repository/TransaccionRepository.java
@@ -7,5 +7,5 @@ import java.util.List;
 import java.util.UUID;
 
 public interface TransaccionRepository extends JpaRepository<Transaccion, UUID> {
-    List<Transaccion> findByUsuario_Id(UUID usuarioId);
+    List<Transaccion> findByUsuario_Id(String usuarioId);
 }

--- a/CrDuels/src/main/java/com/crduels/infrastructure/repository/UsuarioRepository.java
+++ b/CrDuels/src/main/java/com/crduels/infrastructure/repository/UsuarioRepository.java
@@ -2,9 +2,8 @@ package com.crduels.infrastructure.repository;
 
 import com.crduels.domain.model.Usuario;
 import org.springframework.data.jpa.repository.JpaRepository;
-import java.util.UUID;
 
-public interface UsuarioRepository extends JpaRepository<Usuario, UUID> {
+public interface UsuarioRepository extends JpaRepository<Usuario, String> {
     boolean existsByEmail(String email);
     boolean existsByTelefono(String telefono);
     java.util.Optional<Usuario> findByTelefono(String telefono);


### PR DESCRIPTION
## Summary
- use `googleId` from the request as the `Usuario` entity id
- include `googleId` in `UsuarioDto` and mapping logic
- adjust repositories, services and controllers to handle user ids as strings
- update DTOs referencing user ids

## Testing
- `mvn -f CrDuels/pom.xml -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_6855bbfe2924832da8d4708966449714