### PR TITLE
Fix missing import for UUID

### DIFF
--- a/CrDuels/src/main/java/com/crduels/application/dto/TransaccionResponseDto.java
+++ b/CrDuels/src/main/java/com/crduels/application/dto/TransaccionResponseDto.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Data
 @NoArgsConstructor


### PR DESCRIPTION
## Summary
- add missing `java.util.UUID` import in `TransaccionResponseDto`

## Testing
- `mvn -f CrDuels/pom.xml -DskipTests clean package` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent from/to central)*

------
https://chatgpt.com/codex/tasks/task_b_6855be7a65d4832d800048b686851ca5