### PR TITLE
Add Google user registration method

### DIFF
--- a/CrDuels/src/main/java/com/crduels/application/dto/GoogleUserData.java
+++ b/CrDuels/src/main/java/com/crduels/application/dto/GoogleUserData.java
@@ -1,0 +1,15 @@
+package com.crduels.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class GoogleUserData {
+    private String googleId;
+    private String nombre;
+    private String email;
+    private String imagen;
+}

--- a/CrDuels/src/main/java/com/crduels/application/service/UsuarioService.java
+++ b/CrDuels/src/main/java/com/crduels/application/service/UsuarioService.java
@@ -1,6 +1,7 @@
 package com.crduels.application.service;
 
 import com.crduels.application.dto.UsuarioDto;
+import com.crduels.application.dto.GoogleUserData;
 import com.crduels.application.mapper.UsuarioMapper;
 import com.crduels.application.exception.DuplicateUserException;
 import com.crduels.domain.model.Usuario;
@@ -32,6 +33,23 @@ public class UsuarioService {
         Usuario usuario = usuarioMapper.toEntity(dto);
         Usuario saved = usuarioRepository.save(usuario);
         return usuarioMapper.toDto(saved);
+    }
+
+    /**
+     * Registra un usuario a partir de los datos proporcionados por Google.
+     * Si ya existe un usuario con el mismo identificador se devuelve tal cual
+     * sin crear uno nuevo.
+     */
+    public Usuario registrarUsuario(GoogleUserData googleData) {
+        return usuarioRepository.findById(googleData.getGoogleId())
+                .orElseGet(() -> {
+                    Usuario nuevo = new Usuario();
+                    nuevo.setId(googleData.getGoogleId());
+                    nuevo.setNombre(googleData.getNombre());
+                    nuevo.setEmail(googleData.getEmail());
+                    // Campo imagen no se almacena actualmente en la entidad
+                    return usuarioRepository.save(nuevo);
+                });
     }
 
     public Optional<UsuarioDto> obtenerPorId(String id) {


### PR DESCRIPTION
## Summary
- add `GoogleUserData` DTO
- allow registering users using Google data, reusing existing user if present

## Testing
- `mvn -q test -f CrDuels/pom.xml` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6856069ec830832d84614961128379d1