### PR TITLE
Enable fully open CORS configuration

### DIFF
--- a/CrDuels/src/main/java/com/crduels/config/WebConfig.java
+++ b/CrDuels/src/main/java/com/crduels/config/WebConfig.java
@@ -14,9 +14,10 @@ public class WebConfig {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
                 registry.addMapping("/**")
-                        .allowedOrigins("*")
-                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
-                        .allowedHeaders("*");
+                        .allowedOriginPatterns("*")
+                        .allowedMethods("*")
+                        .allowedHeaders("*")
+                        .allowCredentials(true);
             }
         };
     }


### PR DESCRIPTION
## Summary
- allow all origins, methods and headers in `WebConfig`
- permit credentials for cross-origin requests

## Testing
- `mvn -q -f CrDuels/pom.xml test` *(fails: Non-resolvable parent POM, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68560f9faef4832da9d2a9280b50214a