### PR TITLE
Allow full friend link in user signup

### DIFF
--- a/CrDuels/src/main/java/com/crduels/application/dto/UsuarioDto.java
+++ b/CrDuels/src/main/java/com/crduels/application/dto/UsuarioDto.java
@@ -29,7 +29,8 @@ public class UsuarioDto {
     private String tagClash;
 
     @Pattern(
-            regexp = "^(https://link\\.clashroyale\\.com/invite/friend\\?tag=[A-Z0-9]+)?$",
+            // Accept the base friend link and any extra parameters (e.g. token)
+            regexp = "^(https://link\\.clashroyale\\.com/invite/friend\\?tag=[A-Z0-9]+.*)?$",
             message = "Enlace de amistad inválido"
     )
     private String linkAmistad;

--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ Examples using `curl`:
 ```bash
 curl -X POST http://localhost:8080/api/usuarios/registro \
   -H 'Content-Type: application/json' \
-  -d '{"googleId":"gid123","nombre":"Ejemplo","email":"ejemplo@correo.com","telefono":"+52123456789","tagClash":"#ABC123","linkAmistad":"https://link.clashroyale.com/invite/friend?tag=ABC123"}'
+  -d '{"googleId":"gid123","nombre":"Ejemplo","email":"ejemplo@correo.com","telefono":"+52123456789","tagClash":"#ABC123","linkAmistad":"https://link.clashroyale.com/invite/friend?tag=ABC123&token=XYZ"}'
 ```
+You can include the full Clash Royale friend link, including any `token` or other parameters.
 
 * Retrieve a user
 


### PR DESCRIPTION
## Summary
- allow extra parameters when validating `linkAmistad`
- document example friend link with token

## Testing
- `mvn -f CrDuels/pom.xml -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_68562963ffe8832d9da28fd84c13deee