### PR TITLE
Add SSE notifications for transaction approval

### DIFF
--- a/CrDuels/src/main/java/com/crduels/application/controller/SseController.java
+++ b/CrDuels/src/main/java/com/crduels/application/controller/SseController.java
@@ -1,0 +1,23 @@
+package com.crduels.application.controller;
+
+import com.crduels.application.service.SseService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequestMapping("/api/sse")
+public class SseController {
+
+    private final SseService sseService;
+
+    public SseController(SseService sseService) {
+        this.sseService = sseService;
+    }
+
+    @GetMapping("/transacciones")
+    public SseEmitter streamTransacciones() {
+        return sseService.subscribe();
+    }
+}

--- a/CrDuels/src/main/java/com/crduels/application/controller/TransaccionController.java
+++ b/CrDuels/src/main/java/com/crduels/application/controller/TransaccionController.java
@@ -38,6 +38,13 @@ public class TransaccionController {
         return ResponseEntity.ok(lista);
     }
 
+    @PostMapping("/{id}/aprobar")
+    @Operation(summary = "Aprobar transacción", description = "Aprueba la transacción y actualiza el saldo")
+    public ResponseEntity<TransaccionResponseDto> aprobar(@PathVariable UUID id) {
+        TransaccionResponseDto response = transaccionService.aprobarTransaccion(id);
+        return ResponseEntity.ok(response);
+    }
+
     @PutMapping("/{id}/estado")
     @Operation(summary = "Cambiar estado", description = "Actualiza el estado de una transacción")
     public ResponseEntity<TransaccionResponseDto> cambiarEstado(@PathVariable UUID id,

--- a/CrDuels/src/main/java/com/crduels/application/service/SseService.java
+++ b/CrDuels/src/main/java/com/crduels/application/service/SseService.java
@@ -1,0 +1,38 @@
+package com.crduels.application.service;
+
+import com.crduels.infrastructure.dto.TransaccionResponseDto;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+@Service
+public class SseService {
+
+    private final List<SseEmitter> emitters = new CopyOnWriteArrayList<>();
+
+    public SseEmitter subscribe() {
+        SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
+        emitter.onCompletion(() -> emitters.remove(emitter));
+        emitter.onTimeout(() -> emitters.remove(emitter));
+        emitters.add(emitter);
+        return emitter;
+    }
+
+    public void enviarTransaccionAprobada(TransaccionResponseDto dto) {
+        List<SseEmitter> muertos = new ArrayList<>();
+        for (SseEmitter emitter : emitters) {
+            try {
+                emitter.send(SseEmitter.event()
+                        .name("transaccion-aprobada")
+                        .data(dto));
+            } catch (IOException e) {
+                muertos.add(emitter);
+            }
+        }
+        emitters.removeAll(muertos);
+    }
+}


### PR DESCRIPTION
## Summary
- add `SseService` to manage Server-Sent Events
- create `SseController` to provide SSE endpoint
- extend `TransaccionService` to trigger events when approving
- add `/api/transacciones/{id}/aprobar` endpoint
- verify user exists when registering a transaction

## Testing
- `mvn -q -f CrDuels/pom.xml package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68566cb65be0832d83711fb06b35cc84