### PR TITLE
Refactor matchmaking classes into project layers

### DIFF
--- a/CrDuels/src/main/java/com/crduels/application/matchmaking/MatchmakingQueue.java
+++ b/CrDuels/src/main/java/com/crduels/application/matchmaking/MatchmakingQueue.java
@@ -1,0 +1,37 @@
+package com.crduels.application.matchmaking;
+
+import com.crduels.domain.matchmaking.Apuesta;
+import com.crduels.domain.matchmaking.ModoJuego;
+import org.springframework.stereotype.Component;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+/**
+ * Maneja las colas de emparejamiento por cada modo de juego.
+ */
+@Component
+public class MatchmakingQueue {
+
+    private final Map<ModoJuego, ConcurrentLinkedQueue<Apuesta>> colas;
+
+    public MatchmakingQueue() {
+        this.colas = new EnumMap<>(ModoJuego.class);
+        for (ModoJuego modo : ModoJuego.values()) {
+            this.colas.put(modo, new ConcurrentLinkedQueue<>());
+        }
+    }
+
+    public ConcurrentLinkedQueue<Apuesta> obtenerCola(ModoJuego modo) {
+        return colas.get(modo);
+    }
+
+    public void encolar(ModoJuego modo, Apuesta apuesta) {
+        obtenerCola(modo).offer(apuesta);
+    }
+
+    public Apuesta desencolar(ModoJuego modo) {
+        return obtenerCola(modo).poll();
+    }
+}

--- a/CrDuels/src/main/java/com/crduels/application/matchmaking/MatchmakingService.java
+++ b/CrDuels/src/main/java/com/crduels/application/matchmaking/MatchmakingService.java
@@ -1,0 +1,53 @@
+package com.crduels.application.matchmaking;
+
+import com.crduels.domain.entity.Usuario;
+import com.crduels.domain.matchmaking.Apuesta;
+import com.crduels.domain.matchmaking.EstadoApuesta;
+import com.crduels.domain.matchmaking.ModoJuego;
+import com.crduels.application.matchmaking.MatchmakingQueue;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Objects;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+/**
+ * Servicio responsable de gestionar el emparejamiento de apuestas.
+ */
+@Service
+@RequiredArgsConstructor
+public class MatchmakingService {
+
+    private final MatchmakingQueue matchmakingQueue;
+
+    /**
+     * Recibe la solicitud de un jugador para crear una apuesta en cierto modo
+     * de juego. Si existe otra apuesta pendiente en la misma cola se emparejan
+     * y se retorna la apuesta resultante. En caso contrario la nueva apuesta
+     * se almacena como pendiente.
+     *
+     * @param jugador  jugador que desea apostar
+     * @param modoJuego modo de juego elegido
+     * @return la apuesta emparejada o la apuesta pendiente
+     */
+    public synchronized Apuesta registrarApuesta(Usuario jugador, ModoJuego modoJuego) {
+        Objects.requireNonNull(jugador, "jugador1 no puede ser null");
+        Objects.requireNonNull(modoJuego, "modoJuego no puede ser null");
+
+        ConcurrentLinkedQueue<Apuesta> cola = matchmakingQueue.obtenerCola(modoJuego);
+        Apuesta pendiente = cola.poll();
+        if (pendiente != null) {
+            pendiente.setJugador2(jugador);
+            pendiente.setEstado(EstadoApuesta.ACTIVA);
+            return pendiente;
+        }
+
+        Apuesta nueva = Apuesta.builder()
+                .jugador1(jugador)
+                .estado(EstadoApuesta.PENDIENTE)
+                .modoJuego(modoJuego)
+                .build();
+        matchmakingQueue.encolar(modoJuego, nueva);
+        return nueva;
+    }
+}

--- a/CrDuels/src/main/java/com/crduels/domain/matchmaking/Apuesta.java
+++ b/CrDuels/src/main/java/com/crduels/domain/matchmaking/Apuesta.java
@@ -1,0 +1,33 @@
+package com.crduels.domain.matchmaking;
+
+import com.crduels.domain.entity.Usuario;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * Entidad de dominio que representa una apuesta temporal utilizada
+ * durante el proceso de matchmaking.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Apuesta {
+
+    /** Monto fijo de la apuesta en pesos colombianos. */
+    public static final BigDecimal MONTO_FIJO = BigDecimal.valueOf(6000);
+
+    private Usuario jugador1;
+    private Usuario jugador2;
+    @Builder.Default
+    private BigDecimal monto = MONTO_FIJO;
+    private EstadoApuesta estado;
+    private ModoJuego modoJuego;
+    @Builder.Default
+    private LocalDateTime creadaEn = LocalDateTime.now();
+}

--- a/CrDuels/src/main/java/com/crduels/domain/matchmaking/EstadoApuesta.java
+++ b/CrDuels/src/main/java/com/crduels/domain/matchmaking/EstadoApuesta.java
@@ -1,0 +1,15 @@
+package com.crduels.domain.matchmaking;
+
+/**
+ * Estados posibles de una apuesta dentro del sistema de matchmaking.
+ */
+public enum EstadoApuesta {
+    /**
+     * Apuesta esperando por un oponente.
+     */
+    PENDIENTE,
+    /**
+     * Apuesta con ambos jugadores asignados lista para jugar.
+     */
+    ACTIVA
+}

--- a/CrDuels/src/main/java/com/crduels/domain/matchmaking/ModoJuego.java
+++ b/CrDuels/src/main/java/com/crduels/domain/matchmaking/ModoJuego.java
@@ -1,0 +1,15 @@
+package com.crduels.domain.matchmaking;
+
+/**
+ * Modos de juego disponibles para las apuestas.
+ */
+public enum ModoJuego {
+    /**
+     * Batalla clásica 1v1.
+     */
+    BATALLA_CLASICA,
+    /**
+     * Modo de triple elección.
+     */
+    TRIPLE_ELECCION
+}


### PR DESCRIPTION
## Summary
- move FIFO matchmaking service to application layer
- relocate temporary bet model under domain package

## Testing
- `mvn -q -DskipTests package` *(fails to download parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_685729f014d4832db9db021b64efca19