### PR TITLE
Implement SSE matchmaking notifications

### DIFF
--- a/CrDuels/src/main/java/com/crduels/application/controller/SseController.java
+++ b/CrDuels/src/main/java/com/crduels/application/controller/SseController.java
@@ -1,8 +1,10 @@
 package com.crduels.application.controller;
 
 import com.crduels.application.service.SseService;
+import com.crduels.application.service.MatchSseService;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import lombok.RequiredArgsConstructor;
@@ -13,9 +15,15 @@ import lombok.RequiredArgsConstructor;
 public class SseController {
 
     private final SseService sseService;
+    private final MatchSseService matchSseService;
 
     @GetMapping("/transacciones")
     public SseEmitter streamTransacciones() {
         return sseService.subscribe();
+    }
+
+    @GetMapping("/match")
+    public SseEmitter streamMatch(@RequestParam("jugadorId") String jugadorId) {
+        return matchSseService.subscribe(jugadorId);
     }
 }

--- a/CrDuels/src/main/java/com/crduels/application/service/MatchSseService.java
+++ b/CrDuels/src/main/java/com/crduels/application/service/MatchSseService.java
@@ -1,0 +1,51 @@
+package com.crduels.application.service;
+
+import com.crduels.domain.entity.Usuario;
+import com.crduels.infrastructure.dto.rs.MatchSseDto;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class MatchSseService {
+
+    private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+    public SseEmitter subscribe(String jugadorId) {
+        SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
+        emitters.put(jugadorId, emitter);
+        emitter.onCompletion(() -> emitters.remove(jugadorId));
+        emitter.onTimeout(() -> emitters.remove(jugadorId));
+        emitter.onError(ex -> emitters.remove(jugadorId));
+        return emitter;
+    }
+
+    public void notifyMatch(UUID apuestaId, Usuario jugador1, Usuario jugador2) {
+        sendEvent(jugador1.getId(), apuestaId, jugador2);
+        sendEvent(jugador2.getId(), apuestaId, jugador1);
+    }
+
+    private void sendEvent(String receptorId, UUID apuestaId, Usuario oponente) {
+        SseEmitter emitter = emitters.get(receptorId);
+        if (emitter == null) {
+            return;
+        }
+        MatchSseDto dto = MatchSseDto.builder()
+                .apuestaId(apuestaId)
+                .jugadorOponenteId(oponente.getId())
+                .jugadorOponenteTag(oponente.getTagClash())
+                .build();
+        try {
+            emitter.send(SseEmitter.event()
+                    .name("match-found")
+                    .data(dto));
+        } catch (IOException e) {
+            emitters.remove(receptorId);
+            emitter.completeWithError(e);
+        }
+    }
+}

--- a/CrDuels/src/main/java/com/crduels/application/service/MatchmakingService.java
+++ b/CrDuels/src/main/java/com/crduels/application/service/MatchmakingService.java
@@ -1,0 +1,93 @@
+package com.crduels.application.service;
+
+import com.crduels.domain.entity.Apuesta;
+import com.crduels.domain.entity.EstadoApuesta;
+import com.crduels.domain.entity.EstadoSolicitud;
+import com.crduels.domain.entity.SolicitudApuesta;
+import com.crduels.infrastructure.dto.MatchResultDto;
+import com.crduels.infrastructure.dto.rq.ApuestaRequest;
+import com.crduels.infrastructure.dto.rs.ApuestaResponse;
+import com.crduels.infrastructure.repository.SolicitudApuestaRepository;
+import com.crduels.application.service.MatchSseService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class MatchmakingService {
+
+    private final SolicitudApuestaRepository solicitudRepository;
+    private final ApuestaService apuestaService;
+    private final MatchSseService matchSseService;
+
+    /**
+     * Ejecuta el proceso de matchmaking emparejando solicitudes de apuesta con
+     * el mismo monto y modo de juego. Por cada par de solicitudes se crea una
+     * {@link Apuesta} y se retorna un {@link MatchResultDto} con la información
+     * relevante del emparejamiento.
+     */
+    @Transactional
+    public List<MatchResultDto> ejecutarMatchmaking() {
+        List<SolicitudApuesta> pendientes = solicitudRepository.findByEstado(EstadoSolicitud.PENDIENTE);
+
+        // Agrupar por monto y modo de juego
+        Map<Key, List<SolicitudApuesta>> grupos = pendientes.stream()
+                .sorted(Comparator.comparing(SolicitudApuesta::getCreadoEn))
+                .collect(Collectors.groupingBy(s -> new Key(s.getMonto(), s.getModoJuego())));
+
+        List<MatchResultDto> resultados = new ArrayList<>();
+
+        for (List<SolicitudApuesta> grupo : grupos.values()) {
+            for (int i = 0; i + 1 < grupo.size(); i += 2) {
+                SolicitudApuesta s1 = grupo.get(i);
+                SolicitudApuesta s2 = grupo.get(i + 1);
+
+                ApuestaRequest rq = ApuestaRequest.builder()
+                        .jugador1Id(s1.getJugador().getId())
+                        .jugador2Id(s2.getJugador().getId())
+                        .monto(s1.getMonto())
+                        .modoJuego(s1.getModoJuego())
+                        .build();
+
+                ApuestaResponse apuesta = apuestaService.crearApuesta(rq);
+                apuestaService.cambiarEstado(apuesta.getId(), EstadoApuesta.EMPAREJADA);
+
+                s1.setEstado(EstadoSolicitud.EMPAREJADA);
+                s2.setEstado(EstadoSolicitud.EMPAREJADA);
+                solicitudRepository.saveAll(Arrays.asList(s1, s2));
+
+                resultados.add(MatchResultDto.builder()
+                        .apuestaId(apuesta.getId())
+                        .jugador1Id(toUuid(s1.getJugador().getId()))
+                        .jugador2Id(toUuid(s2.getJugador().getId()))
+                        .monto(apuesta.getMonto())
+                        .modoJuego(apuesta.getModoJuego())
+                        .build());
+
+                matchSseService.notifyMatch(apuesta.getId(), s1.getJugador(), s2.getJugador());
+            }
+        }
+
+        return resultados;
+    }
+
+    private UUID toUuid(String id) {
+        try {
+            return UUID.fromString(id);
+        } catch (IllegalArgumentException ex) {
+            return UUID.nameUUIDFromBytes(id.getBytes(StandardCharsets.UTF_8));
+        }
+    }
+
+    /**
+     * Llave para el agrupamiento por monto y modo de juego.
+     */
+    private record Key(BigDecimal monto, String modo) {
+    }
+}

--- a/CrDuels/src/main/java/com/crduels/infrastructure/dto/rs/MatchSseDto.java
+++ b/CrDuels/src/main/java/com/crduels/infrastructure/dto/rs/MatchSseDto.java
@@ -1,0 +1,23 @@
+package com.crduels.infrastructure.dto.rs;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MatchSseDto implements Serializable {
+    @Serial
+    private static final long serialVersionUID = -5076615234782375916L;
+
+    private UUID apuestaId;
+    private String jugadorOponenteId;
+    private String jugadorOponenteTag;
+}


### PR DESCRIPTION
## Summary
- add a `MatchSseService` to manage SSE emitters per player
- expose `/api/sse/match` endpoint for clients to wait for matchmaking
- notify players through SSE when `MatchmakingService` pairs them

## Testing
- `mvn -q -f CrDuels/pom.xml test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68577b6e5cf8832db34d8706a8b2a675