### PR TITLE
Implement realtime matchmaking queue with SSE

### DIFF
--- a/CrDuels/src/main/java/com/crduels/application/controller/MatchmakingController.java
+++ b/CrDuels/src/main/java/com/crduels/application/controller/MatchmakingController.java
@@ -1,16 +1,14 @@
 package com.crduels.application.controller;
 
-import com.crduels.infrastructure.dto.MatchResultDto;
-import com.crduels.application.service.MatchmakingService;
+import com.crduels.infrastructure.dto.rq.MatchmakingJoinRequest;
+import com.crduels.application.service.RealtimeMatchmakingService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import lombok.RequiredArgsConstructor;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/matchmaking")
@@ -18,12 +16,23 @@ import java.util.List;
 @RequiredArgsConstructor
 public class MatchmakingController {
 
-    private final MatchmakingService matchmakingService;
+    private final RealtimeMatchmakingService realtimeMatchmakingService;
 
     @PostMapping("/ejecutar")
-    @Operation(summary = "Ejecutar", description = "Ejecuta el proceso de matchmaking")
-    public ResponseEntity<List<MatchResultDto>> ejecutar() {
-        List<MatchResultDto> resultados = matchmakingService.ejecutarMatchmaking();
-        return ResponseEntity.ok(resultados);
+    @Operation(summary = "Ejecutar", description = "Registra un jugador en el matchmaking")
+    public ResponseEntity<Map<String, String>> ejecutar(@RequestBody MatchmakingJoinRequest dto) {
+        boolean match = realtimeMatchmakingService.joinQueue(dto);
+        String status = match ? "emparejado" : "esperando";
+        return ResponseEntity.ok(Map.of("status", status));
+    }
+
+    @PostMapping("/cancelar")
+    @Operation(summary = "Cancelar", description = "Cancela la espera del jugador")
+    public ResponseEntity<Void> cancelar(@RequestBody Map<String, String> body) {
+        String usuarioId = body.get("usuarioId");
+        if (usuarioId != null) {
+            realtimeMatchmakingService.cancelar(usuarioId);
+        }
+        return ResponseEntity.ok().build();
     }
 }

--- a/CrDuels/src/main/java/com/crduels/application/controller/SseController.java
+++ b/CrDuels/src/main/java/com/crduels/application/controller/SseController.java
@@ -2,7 +2,9 @@ package com.crduels.application.controller;
 
 import com.crduels.application.service.SseService;
 import com.crduels.application.service.MatchSseService;
+import com.crduels.application.service.RealtimeMatchmakingService;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -16,6 +18,7 @@ public class SseController {
 
     private final SseService sseService;
     private final MatchSseService matchSseService;
+    private final RealtimeMatchmakingService realtimeMatchmakingService;
 
     @GetMapping("/transacciones")
     public SseEmitter streamTransacciones() {
@@ -25,5 +28,10 @@ public class SseController {
     @GetMapping("/match")
     public SseEmitter streamMatch(@RequestParam("jugadorId") String jugadorId) {
         return matchSseService.subscribe(jugadorId);
+    }
+
+    @GetMapping("/matchmaking/{usuarioId}")
+    public SseEmitter streamMatchmaking(@PathVariable String usuarioId) {
+        return realtimeMatchmakingService.subscribe(usuarioId);
     }
 }

--- a/CrDuels/src/main/java/com/crduels/application/service/RealtimeMatchmakingService.java
+++ b/CrDuels/src/main/java/com/crduels/application/service/RealtimeMatchmakingService.java
@@ -1,0 +1,105 @@
+package com.crduels.application.service;
+
+import com.crduels.infrastructure.dto.rq.MatchmakingJoinRequest;
+import com.crduels.infrastructure.dto.rs.MatchmakingPartidaDto;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Queue;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+@Service
+public class RealtimeMatchmakingService {
+
+    private static class Player {
+        final String usuarioId;
+        final String modoJuego;
+
+        Player(String usuarioId, String modoJuego) {
+            this.usuarioId = usuarioId;
+            this.modoJuego = modoJuego;
+        }
+    }
+
+    private final Queue<Player> waitingQueue = new ConcurrentLinkedQueue<>();
+    private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+    /**
+     * Register a player into the matchmaking queue.
+     * @return true if a match was made immediately, false if player must wait
+     */
+    public synchronized boolean joinQueue(MatchmakingJoinRequest request) {
+        if (waitingQueue.stream().anyMatch(p -> p.usuarioId.equals(request.getUsuarioId()))) {
+            return false; // already waiting
+        }
+        Player opponent = waitingQueue.poll();
+        if (opponent == null) {
+            waitingQueue.add(new Player(request.getUsuarioId(), request.getModoJuego()));
+            return false;
+        }
+        Player current = new Player(request.getUsuarioId(), request.getModoJuego());
+        emparejarJugadores(current, opponent);
+        return true;
+    }
+
+    public SseEmitter subscribe(String usuarioId) {
+        SseEmitter emitter = new SseEmitter(30_000L);
+        emitters.put(usuarioId, emitter);
+        emitter.onCompletion(() -> emitters.remove(usuarioId));
+        emitter.onError(e -> emitters.remove(usuarioId));
+        emitter.onTimeout(() -> {
+            sendTimeout(usuarioId);
+            emitters.remove(usuarioId);
+        });
+        return emitter;
+    }
+
+    public void cancelar(String usuarioId) {
+        waitingQueue.removeIf(p -> p.usuarioId.equals(usuarioId));
+        SseEmitter emitter = emitters.remove(usuarioId);
+        if (emitter != null) {
+            emitter.complete();
+        }
+    }
+
+    private void sendTimeout(String usuarioId) {
+        SseEmitter emitter = emitters.get(usuarioId);
+        if (emitter == null) {
+            return;
+        }
+        try {
+            emitter.send(SseEmitter.event().name("timeout").data(Map.of("timeout", true)));
+            emitter.complete();
+        } catch (IOException e) {
+            emitter.completeWithError(e);
+        }
+    }
+
+    private void emparejarJugadores(Player p1, Player p2) {
+        MatchmakingPartidaDto partida = MatchmakingPartidaDto.builder()
+                .partidaId(UUID.randomUUID())
+                .jugador1Id(p1.usuarioId)
+                .jugador2Id(p2.usuarioId)
+                .modoJuego(p1.modoJuego)
+                .build();
+        sendMatch(p1.usuarioId, partida);
+        sendMatch(p2.usuarioId, partida);
+    }
+
+    private void sendMatch(String usuarioId, MatchmakingPartidaDto partida) {
+        SseEmitter emitter = emitters.remove(usuarioId);
+        if (emitter == null) {
+            return;
+        }
+        try {
+            emitter.send(SseEmitter.event().name("match").data(partida));
+            emitter.complete();
+        } catch (IOException e) {
+            emitter.completeWithError(e);
+        }
+    }
+}

--- a/CrDuels/src/main/java/com/crduels/infrastructure/dto/rq/MatchmakingJoinRequest.java
+++ b/CrDuels/src/main/java/com/crduels/infrastructure/dto/rq/MatchmakingJoinRequest.java
@@ -1,0 +1,25 @@
+package com.crduels.infrastructure.dto.rq;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MatchmakingJoinRequest implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    @NotEmpty
+    private String usuarioId;
+
+    @NotEmpty
+    private String modoJuego;
+}

--- a/CrDuels/src/main/java/com/crduels/infrastructure/dto/rs/MatchmakingPartidaDto.java
+++ b/CrDuels/src/main/java/com/crduels/infrastructure/dto/rs/MatchmakingPartidaDto.java
@@ -1,0 +1,24 @@
+package com.crduels.infrastructure.dto.rs;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MatchmakingPartidaDto implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    private UUID partidaId;
+    private String jugador1Id;
+    private String jugador2Id;
+    private String modoJuego;
+}


### PR DESCRIPTION
## Summary
- add `RealtimeMatchmakingService` for queue-based matchmaking
- expose POST `/api/matchmaking/ejecutar` and `/api/matchmaking/cancelar`
- provide SSE endpoint `/sse/matchmaking/{usuarioId}`
- add DTOs for matchmaking requests and SSE responses

## Testing
- `mvn -q -DskipTests package` *(fails: Could not resolve Spring parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_6857a14c57c4832db3a08b1caa43ffe1